### PR TITLE
Fix uninitialized variable when scanning for BMS

### DIFF
--- a/dbushelper.py
+++ b/dbushelper.py
@@ -210,6 +210,7 @@ class DbusHelper:
         # Battery Values
         available_devices = self._dbusConnection.list_names()
         device_found = None
+        hasVictronBMS = False
 
         for i in range(10):  # Annahme: Überprüfen von ttyUSB0 bis ttyUSB9
             device_name = f'com.victronenergy.battery.ttyUSB{i}'


### PR DESCRIPTION
## Summary
- initialize `hasVictronBMS` to avoid `UnboundLocalError` if no Victron BMS is detected

## Testing
- `python3 -m py_compile dbushelper.py`

------
https://chatgpt.com/codex/tasks/task_b_687eaa6ab1e48333a9a066fe5c6e74d2