### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ Special thanks goes to the following for the basis of this modified code:
 * https://github.com/bradcagle/dbus-btbattery <br>
 * https://github.com/victronenergy/velib_python <br>
 
-And all other authors and community members of victron which developed or helped to develop drivers, services and componentes
+And all other authors and community members of victron which developed or helped to develop drivers, services and components
 # Inverters
 This is a driver for VenusOS devices.
 
 The driver will communicate with PIP/Axpert/Infinisolar/Voltronic/PowLand/OutBack and other compatible solar inverters via Bluetooth <br/>
 and publish this data to the VenusOS system.
 
-!!! System need to have bluetooth supported panel, in range!
+!!! System needs to have a Bluetooth-supported panel in range!
 see images
 ![screenshot](docs/panel.png)
 ![screenshot](docs/panel_LCD.png)
 
 ## Prerequisites
-You need to setup some depenacies on your VenusOS first:
+You need to setup some dependencies on your VenusOS first:
 
 1) SSH to IP assigned to VenusOS device<br/>
 
@@ -49,13 +49,13 @@ opkg install packagegroup-core-buildessential
 opkg install libglib-2.0-dev
 ```
 
-7) Install bluepi<br/>
+7) Install bluepy<br/>
 ```sh
 pip3 install bluepy
 ```
 
 ## Installation
-When you install with one of these methods the system will take care of starting the service and keep it running. You might want to start things manually. IN this case do not use SetupHelper method. Install manually put skip the install script. After that you can proceed with configuration and testing manually section.
+When you install with one of these methods the system will take care of starting the service and keep it running. You might want to start things manually. In this case, do not use the SetupHelper method. Install manually but skip the install script. After that you can proceed with the configuration and testing manually section.
 
 ### Install with SetupHelper from kwindrem
 
@@ -75,9 +75,9 @@ Github branch or tag: `main` <br>
 opkg install git
 ```
 
-2) switch to victronenergy directory
+2) Switch to the victronenergy directory
 ```sh
-cd /opt/victronenerg
+cd /opt/victronenergy
 ```
 
 3) Clone OutbackSPC repo<br/>
@@ -95,7 +95,7 @@ run ./installservice.sh
 reboot
 ```
 ## Configuration
-#### Due to the fact that we have to connect to the device to read the data (I don't think it is has implemented notifiy functionality - maybe I am wrong ;-) we have to trust and pair our device manually before we can use it with our service.
+#### Due to the fact that we have to connect to the device to read the data (I don't think it has implemented notify functionality - maybe I am wrong ;-) we have to trust and pair our device manually before we can use it with our service.
 
 1) select our service directory
 ```sh
@@ -107,9 +107,9 @@ cd /data/OutbackSPC
 ```
 
 2) scan for nearby devices
-./scan.py`
+./scan.py
 
-After you have found out the mac adress of your device you have to make the device connectable.<br/> 
+After you have found out the mac address of your device you have to make the device connectable.<br/> 
 replace xx:xx:xx:xx:xx:xx with the Bluetooth address of your Inverter<br/>
 ```sh
 ./scan.py
@@ -127,7 +127,7 @@ trust xx:xx:xx:xx:xx:xx
 pair xx:xx:xx:xx:xx:xx
 ```
 (enter 000000 or 123456)
-6) connect optionaly to verify connection<br>
+6) connect optionally to verify connection<br>
 ```sh
 connect xx:xx:xx:xx:xx:xx
 ```
@@ -158,5 +158,5 @@ reboot
 /var/log/OutbackSPC
 ```
 
-# NOTES: This driver is is still in development and may not work as intended. Use at your own risk!
+# NOTES: This driver is still in development and may not work as intended. Use at your own risk!
 


### PR DESCRIPTION
## Summary
- fix typos in README instructions
- minor grammar fixes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687eb6b416cc83339900eead35f64b42