### PR TITLE
Fix shebang in scan.py

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 test
+#!/usr/bin/env python3
 from bluepy.btle import Scanner, DefaultDelegate
 
 class ScanDelegate(DefaultDelegate):


### PR DESCRIPTION
## Summary
- fix typo in the scan.py shebang

## Testing
- `python3 -m py_compile scan.py`
- `python3 scan.py` *(fails: ModuleNotFoundError: No module named 'bluepy')*

------
https://chatgpt.com/codex/tasks/task_b_687eb6ba8ae8833390cd582f2fed5da5