### PR TITLE
Ensure bluetooth connections close on errors

### DIFF
--- a/outbackbt.py
+++ b/outbackbt.py
@@ -24,6 +24,12 @@ class OutbackBtDev(DefaultDelegate, Thread):
         self.bt = Peripheral()
         self.bt.setDelegate(self)
 
+    def _disconnect_bt(self):
+        try:
+            self.bt.disconnect()
+        except Exception as e:
+            logger.debug('Disconnect error: %s', e)
+
     def run(self):
         self.running = True
         connected = False
@@ -41,6 +47,7 @@ class OutbackBtDev(DefaultDelegate, Thread):
                     logger.info(ex)
                     e = sys.exc_info()
                     logger.info(e)
+                    self._disconnect_bt()
                     time.sleep(2)
                     logger.info('restarting and reseting bluetooth')
                     os.system('/etc/init.d/bluetooth restart; hciconfig hci0 reset')
@@ -133,10 +140,12 @@ class OutbackBtDev(DefaultDelegate, Thread):
 
             except BTLEDisconnectError:
                 logger.info('Disconnected' + str(BTLEDisconnectError))
+                self._disconnect_bt()
                 connected = False
                 continue
             except Exception as error:
                 logger.info('ERROR:' + str(error))
+                self._disconnect_bt()
 
     def connect(self):
         if self.debug:
@@ -145,6 +154,7 @@ class OutbackBtDev(DefaultDelegate, Thread):
 
     def stop(self):
         self.running = False
+        self._disconnect_bt()
 
     def addGeneralDataCallback(self, func):
         self.generalDataCallback = func


### PR DESCRIPTION
## Summary
- add `_disconnect_bt` helper in `OutbackBtDev`
- disconnect bluetooth on stop and on errors in `run`

## Testing
- `python3 -m py_compile outbackbt.py`


------
https://chatgpt.com/codex/tasks/task_b_687eb63600e483339fe4c18f002e179c