### PR TITLE
Fix delegate setup in OutbackBt

### DIFF
--- a/outbackbt.py
+++ b/outbackbt.py
@@ -166,8 +166,10 @@ class OutbackBt(Inverter):
         self.debug = utils.DEBUG_MODE
 
         # Bluepy stuff
+        # OutbackBt does not handle BLE notifications directly, so no
+        # delegate is registered here.  The OutbackBtDev helper class
+        # manages all Bluetooth communication and callbacks.
         self.bt = Peripheral()
-        self.bt.setDelegate(self)
 
         self.mutex = Lock()
         self.a03Data = None


### PR DESCRIPTION
## Summary
- avoid registering `OutbackBt` as a BLE delegate since it does not handle notifications

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687eb51068c88333873bfb87501f9da4